### PR TITLE
Oauth2 without OOB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.3] - 2022-03-19
+### Changed
+
+- Does not use OAuth out-of-band (oob) anymore as it is deprecated
+
 ## [1.3.2] - 2021-11-17
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -205,6 +205,8 @@
 	},
 	"dependencies": {
 		"googleapis": "52.1.0",
+		"google-auth-library": "7.14.0",
+		"server-destroy": "1.0.1",
 		"keytar": "6.0.1",
 		"mime-types": "2.1.27",
 		"archiver": "4.0.2"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	},
 	"license": "MIT",
 	"publisher": "GustavoASC",
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"icon": "img/icon.png",
 	"engines": {
 		"vscode": "^1.43.0"

--- a/src/auth/driveAuthenticator.ts
+++ b/src/auth/driveAuthenticator.ts
@@ -1,11 +1,19 @@
 import { env, Uri, window, commands } from "vscode";
 import { CredentialsManager, CREDENTIALS_JSON_SERVICE, TOKENS_JSON_SERVICE } from "../drive/credentials/credentialsManager";
+const { OAuth2Client } = require('google-auth-library');
 const { google } = require('googleapis');
+const http = require('http');
+const url = require('url');
+const destroyer = require('server-destroy');
 import * as fs from "fs";
 import { CONFIGURE_CREDENTIALS_COMMAND } from "../extension";
 
 // If modifying these scopes, delete token.json.
 const SCOPES = ['https://www.googleapis.com/auth/drive.file', 'https://www.googleapis.com/auth/drive', 'https://www.googleapis.com/auth/drive.readonly'];
+
+// Port and endpoint where this extension will listen for the OAuth2 token
+const OAUTH_PORT = 3000;
+const OAUTH_ENDPOINT = "http://127.0.0.1:" + OAUTH_PORT + "/";
 
 export class DriveAuthenticator {
 
@@ -106,13 +114,12 @@ export class DriveAuthenticator {
   private authorize(credentials: any): Promise<void> {
     return new Promise((resolve, reject) => {
       const { client_secret, client_id, redirect_uris } = credentials.installed;
-      this.oAuth2Client = new google.auth.OAuth2(
+      this.oAuth2Client = new OAuth2Client(
         client_id,
         client_secret,
-        redirect_uris[0]
+        OAUTH_ENDPOINT
       );
-      this.credentialsManager.retrievePassword(TOKENS_JSON_SERVICE)
-        .then(token => {
+      this.credentialsManager.retrievePassword(TOKENS_JSON_SERVICE).then(token => {
           const tokenJson = JSON.parse(token.toString());
           this.oAuth2Client.setCredentials(tokenJson);
           resolve();
@@ -128,37 +135,99 @@ export class DriveAuthenticator {
 
   private async getAccessToken(): Promise<void> {
     return new Promise(async (resolve, reject) => {
+      
+      // This URL will be opened on external browser so the user can proceed with authentication
       const authUrl = this.oAuth2Client.generateAuthUrl({ access_type: 'offline', scope: SCOPES });
-      window.showInformationMessage('Authorize this app by visiting the external URL and paste in the auth token');
-      const opened = await env.openExternal(Uri.parse(authUrl));
-      if (!opened) {
-        // User has cancelled the authorization flow
-        window.showWarningMessage('Authorization flow canceled by user.');
-        return reject();
-      }
-      const authToken = await window.showInputBox({
-        ignoreFocusOut: true,
-        prompt: 'Paste here the auth token'
-      });
-      if (authToken) {
-        this.oAuth2Client.getToken(authToken, (err: any, token: any) => {
-          if (err) {
-            return reject(err);
+      window.showInformationMessage('Authorize this app by visiting the external URL');
+
+      // Open an http server to accept the oauth callback. In this simple example, the
+      // only request to our webserver is to /oauth2callback?code=<code>
+
+      // This code was extracted from: https://github.com/googleapis/google-auth-library-nodejs
+      const server = http.createServer(async (req: any, res: any) => {
+        try {
+
+          // This is called when user confirms authorization
+          if (req.url.indexOf('/?code') > -1) {
+            
+            // Acquire the code from the querystring, and close the web server.
+            const qs = new url.URL(req.url, OAUTH_ENDPOINT).searchParams;
+            const authToken = qs.get('code');
+            res.end('Authentication completed! Please return to VSCode.');
+            
+            // We do not need the server anymore, so destroy it
+            server.destroy();
+            // Generates a token with the code returned by the auth
+            this.oAuth2Client.getToken(authToken, (err: any, token: any) => {
+              
+              // In case any unexpected error happens we cannot proceed
+              if (err)
+                return reject(err);
+              
+              // This token is stored globally, on this instance, so the authentication is not
+              // asked again on future operations with Google Drive
+              this.token = token;
+
+              // We generate a string representation of the token so it can be stored
+              const stringified = JSON.stringify(this.token);
+
+              // We store the token on the operating system so that different VSCode instances can also
+              // use this token and auth is not asked again in the future.
+              this.credentialsManager.storePassword(stringified, TOKENS_JSON_SERVICE).then(() => {
+
+                // Finally, update the credentials with the generated token
+                this.oAuth2Client.setCredentials(this.token);
+                window.showInformationMessage('Authorization completed! Now you can access your drive files through VSCode.');
+                resolve();
+
+              }).catch(err => {
+                reject(err);
+              });
+            });
           }
-          this.token = token;
-          const stringified = JSON.stringify(this.token);
-          this.credentialsManager.storePassword(stringified, TOKENS_JSON_SERVICE)
-            .then(() => {
-              this.oAuth2Client.setCredentials(this.token);
-              window.showInformationMessage('Authorization completed! Now you can access your drive files through VSCode.');
-              resolve();
-            }).catch(err => reject(err));
-        });
-      } else {
+
+          // This is called when user cancels the authorization
+          if (req.url.indexOf('/?error') > -1) {
+
+            // We do not need the server anymore, so destroy it
+            res.end('Authorization flow canceled by user. Please return to VSCode.');
+            server.destroy();
+
+            // Finishes the authorization
+            window.showWarningMessage('Authorization flow canceled by user.');
+            reject();
+  
+          }
+
+        } catch (err) {
+          window.showErrorMessage('Unexpected problem: ' + err);
+          reject(err);
+        }
+      });
+
+      server.on('error', function (err: any) {
+        window.showErrorMessage('Unexpected problem while starting HTTP server ' + OAUTH_ENDPOINT + ': ' + err);
+        server.destroy();
+        reject(err);
+      });      
+
+      // Effectively listens on the HTTP port until OAuth2 sends a request to it
+      server.listen(OAUTH_PORT, async () => {
+
+        // Opens the browser to the authorize url to start the workflow
+        const opened = await env.openExternal(Uri.parse(authUrl));
+
         // User has cancelled the authorization flow
-        window.showWarningMessage('Authorization flow canceled by user.');
-        reject();
-      }
+        if (!opened) {
+          window.showWarningMessage('Authorization flow canceled by user.');
+          return reject();
+        }
+
+      });
+
+      // Allows this server instance to be properly destroyed
+      destroyer(server);
+
     });
   }
 }


### PR DESCRIPTION
This PR fixes #29.

Now temporarily starts an HTTP server to listen to requests made by OAuth2 authentication flow, instead of copying / pasting the token on VSCode.